### PR TITLE
Updated 3-amazoncorretto-11 with 3.9.2-amazoncorretto-11 to fix the issue

### DIFF
--- a/Jenkinsfile-ci-cd
+++ b/Jenkinsfile-ci-cd
@@ -26,7 +26,7 @@ pipeline {
         }
         stage ("Sonar Cloud Analysis - SAST") {
             agent {
-                docker { image 'maven:3-amazoncorretto-11'
+                docker { image 'maven:3.9.2-amazoncorretto-11'
                 reuseNode true
                 }
             }
@@ -55,7 +55,7 @@ pipeline {
         }
         stage ("Build & Verify") {
             agent {
-                docker { image 'maven:3-amazoncorretto-11'
+                docker { image 'maven:3.9.2-amazoncorretto-11'
                 reuseNode true
                 }
             }


### PR DESCRIPTION
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:3.1.0:run (create-empty-directory-and-english-properties) on project easybuggy: You are using 'tasks' which has been removed from the maven-antrun-plugin. Please use 'target' and refer to the >>Major Version Upgrade to version 3.0.0<< on the plugin site. -> [Help 1]